### PR TITLE
Fix makefile and add stuff to gitignoree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
-main.c.orig
-tags
-xcsyncd
+/main.c.orig
+/tags
+/xcsyncd
+/xcsyncd_debug
+/cmdline.c
+/cmdline.h
+/cmdline.o

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,11 @@ ifndef GGO_EXISTS
 	$(error "There is no gengetopt on this system.")
 endif
 
-cmdline: xcsyncd.ggo check_gengetopt
+cmdline.o: xcsyncd.ggo check_gengetopt
 	gengetopt --input=xcsyncd.ggo
 	gcc -c -o cmdline.o cmdline.c
 
-xcsyncd: cmdline.o main.c 
+xcsyncd: cmdline.o main.c
 	gcc -o $@ ${LIBS} $^
 
 xcsyncd_debug: cmdline.o main.c


### PR DESCRIPTION
There was an error "No rule to make target 'cmdline.o'" when I tried to build xcsyncd target, I fixed it, also I fixed not ignored generated files.